### PR TITLE
DPDK backend: Fix action selector for PNA

### DIFF
--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -147,10 +147,8 @@ const IR::Node *ConvertToDpdkArch::postorder(IR::Type_Control *c) {
     }
     // Ingress, Egress, IngressDeparser, EgressDeparser are reserved name in psa.p4
     if (c->name == "Ingress" || c->name == "Egress") {
-        structure->p4arch = "psa";
         t = rewriteControlType(c, c->name);
     } else if (c->name == "MainControlT") {
-        structure->p4arch = "pna";
         t = rewriteControlType(c, c->name);
     } else if (c->name == "PreControlT") {
         t = rewriteControlType(c, c->name);
@@ -1230,7 +1228,15 @@ const IR::P4Table* SplitP4TableCommon::create_group_table(const IR::P4Table* tbl
 const IR::Node* SplitActionSelectorTable::postorder(IR::P4Table* tbl) {
     bool isConstructedInPlace = false;
     bool isAsInstanceShared = false;
-    auto instance = Helpers::getExternInstanceFromProperty(tbl, "psa_implementation",
+    cstring implementation = "psa_implementation";
+
+    if (structure->isPSA()) {
+        implementation = "psa_implementation";
+    } else if (structure->isPNA()) {
+        implementation = "pna_implementation";
+    }
+
+    auto instance = Helpers::getExternInstanceFromProperty(tbl, implementation,
                                                            refMap, typeMap, &isConstructedInPlace);
     if (!instance)
         return tbl;
@@ -1342,7 +1348,13 @@ const IR::Node* SplitActionSelectorTable::postorder(IR::P4Table* tbl) {
 const IR::Node* SplitActionProfileTable::postorder(IR::P4Table* tbl) {
     bool isConstructedInPlace = false;
     bool isApInstanceShared = false;
-    auto instance = Helpers::getExternInstanceFromProperty(tbl, "psa_implementation",
+    cstring implementation = "psa_implementation";
+    if (structure->isPSA())
+        implementation = "psa_implementation";
+    else if (structure->isPNA())
+        implementation = "pna_implementation";
+
+    auto instance = Helpers::getExternInstanceFromProperty(tbl, implementation,
             refMap, typeMap, &isConstructedInPlace);
 
     if (!instance || instance->type->name != "ActionProfile")

--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -1230,9 +1230,7 @@ const IR::Node* SplitActionSelectorTable::postorder(IR::P4Table* tbl) {
     bool isAsInstanceShared = false;
     cstring implementation = "psa_implementation";
 
-    if (structure->isPSA()) {
-        implementation = "psa_implementation";
-    } else if (structure->isPNA()) {
+    if (structure->isPNA()) {
         implementation = "pna_implementation";
     }
 
@@ -1349,9 +1347,8 @@ const IR::Node* SplitActionProfileTable::postorder(IR::P4Table* tbl) {
     bool isConstructedInPlace = false;
     bool isApInstanceShared = false;
     cstring implementation = "psa_implementation";
-    if (structure->isPSA())
-        implementation = "psa_implementation";
-    else if (structure->isPNA())
+
+    if (structure->isPNA())
         implementation = "pna_implementation";
 
     auto instance = Helpers::getExternInstanceFromProperty(tbl, implementation,

--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -98,8 +98,7 @@ class InjectJumboStruct : public Transform {
 // This pass injects metadata field which is used as port for 'tx' instruction
 // into the single metadata struct.
 // This pass has to be applied after CollectMetadataHeaderInfo fills
-// local_metadata_type field and ConvertToDpdkArch fills p4arch field of
-// DpdkProgramStructure which is passed to the constructor.
+// local_metadata_type field DpdkProgramStructure which is passed to the constructor.
 class InjectOutputPortMetadataField : public Transform {
     DpdkProgramStructure *structure;
 

--- a/backends/dpdk/dpdkProgramStructure.cpp
+++ b/backends/dpdk/dpdkProgramStructure.cpp
@@ -12,6 +12,7 @@ bool ParseDpdkArchitecture::preorder(const IR::ToplevelBlock* block) {
 }
 
 void ParseDpdkArchitecture::parse_pna_block(const IR::PackageBlock *block) {
+    structure->p4arch = "pna";
     auto p = block->findParameterValue("main_parser");
     if (p == nullptr) {
         ::error("Package %1% has no parameter named 'main_parser'", block);
@@ -33,6 +34,7 @@ void ParseDpdkArchitecture::parse_pna_block(const IR::PackageBlock *block) {
 }
 
 void ParseDpdkArchitecture::parse_psa_block(const IR::PackageBlock *block) {
+    structure->p4arch = "psa";
     auto pkg = block->findParameterValue("ingress");
     if (pkg == nullptr) {
         ::error("Package %1% has no parameter named 'ingress'", block);

--- a/backends/dpdk/dpdkProgramStructure.h
+++ b/backends/dpdk/dpdkProgramStructure.h
@@ -70,9 +70,7 @@ struct DpdkProgramStructure {
     /**
      * @brief Predicate that states whether architecture is PSA or not.
      *
-     * Architecture is known only after pass ConvertToDpdkArch.
-     * See method:
-     * const IR::Node *ConvertToDpdkArch::postorder(IR::Type_Control *c)
+     * Architecture is known pass after ParseDpdkArchitecture
      *
      * @return true If architecture is PSA.
      * @return false If architecture is not PSA.
@@ -84,9 +82,7 @@ struct DpdkProgramStructure {
     /**
      * @brief Predicate that states whether architecture is PNA or not.
      *
-     * Architecture is known only after pass ConvertToDpdkArch.
-     * See method:
-     * const IR::Node *ConvertToDpdkArch::postorder(IR::Type_Control *c)
+     * Architecture is known pass after ParseDpdkArchitecture
      *
      * @return true If architecture is PNA.
      * @return false If architecture is not PNA.

--- a/testdata/p4_16_samples/pna-action-selector.p4
+++ b/testdata/p4_16_samples/pna-action-selector.p4
@@ -1,0 +1,145 @@
+/*
+Copyright 2022 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include "pna.p4"
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+//////////////////////////////////////////////////////////////////////
+// Struct types for holding user-defined collections of headers and
+// metadata in the P4 developer's program.
+//
+// Note: The names of these struct types are completely up to the P4
+// developer, as are their member fields, with the only restriction
+// being that the structs intended to contain headers should only
+// contain members whose types are header, header stack, or
+// header_union.
+//////////////////////////////////////////////////////////////////////
+
+struct main_metadata_t {
+    bit<16> data;
+}
+
+// User-defined struct containing all of those headers parsed in the
+// main parser.
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t ipv4;
+}
+
+control PreControlImpl(
+    in    headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd)
+{
+    apply {
+    }
+}
+
+parser MainParserImpl(
+    packet_in pkt,
+    out   headers_t       hdr,
+    inout main_metadata_t main_meta,
+    in    pna_main_parser_input_metadata_t istd)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(
+    inout headers_t       hdr,           // from main parser
+    inout main_metadata_t user_meta,     // from main parser, to "next block"
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd)
+{
+    ActionSelector(PNA_HashAlgorithm_t.TARGET_DEFAULT, 32w1024, 32w16) as;
+    action a1(bit<48> param) { hdr.ethernet.dstAddr = param; }
+    action a2(bit<16> param) { hdr.ethernet.etherType = param; }
+
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr : exact;
+            user_meta.data : selector;
+        }
+        actions = { NoAction; a1; a2; }
+        pna_implementation = as;
+    }
+
+ 
+    apply {
+        tbl.apply();
+    }
+}
+
+control MainDeparserImpl(
+    packet_out pkt,
+    in    headers_t hdr,                // from main control
+    in    main_metadata_t user_meta,    // from main control
+    in    pna_main_output_metadata_t ostd)
+{
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+// BEGIN:Package_Instantiation_Example
+PNA_NIC(
+    MainParserImpl(),
+    PreControlImpl(),
+    MainControlImpl(),
+    MainDeparserImpl()
+    // Hoping to make this optional parameter later, but not supported
+    // by p4c yet.
+    //, PreParserImpl()
+    ) main;
+// END:Package_Instantiation_Example

--- a/testdata/p4_16_samples_outputs/pna-action-selector-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-action-selector-first.p4
@@ -1,0 +1,91 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct main_metadata_t {
+    bit<16> data;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    ActionSelector(PNA_HashAlgorithm_t.TARGET_DEFAULT, 32w1024, 32w16) as;
+    action a1(bit<48> param) {
+        hdr.ethernet.dstAddr = param;
+    }
+    action a2(bit<16> param) {
+        hdr.ethernet.etherType = param;
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+            user_meta.data      : selector @name("user_meta.data") ;
+        }
+        actions = {
+            NoAction();
+            a1();
+            a2();
+        }
+        pna_implementation = as;
+        default_action = NoAction();
+    }
+    apply {
+        tbl.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-action-selector-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-action-selector-frontend.p4
@@ -1,0 +1,93 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct main_metadata_t {
+    bit<16> data;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("MainControlImpl.as") ActionSelector(PNA_HashAlgorithm_t.TARGET_DEFAULT, 32w1024, 32w16) as_0;
+    @name("MainControlImpl.a1") action a1(@name("param") bit<48> param) {
+        hdr.ethernet.dstAddr = param;
+    }
+    @name("MainControlImpl.a2") action a2(@name("param") bit<16> param_2) {
+        hdr.ethernet.etherType = param_2;
+    }
+    @name("MainControlImpl.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+            user_meta.data      : selector @name("user_meta.data") ;
+        }
+        actions = {
+            NoAction_1();
+            a1();
+            a2();
+        }
+        pna_implementation = as_0;
+        default_action = NoAction_1();
+    }
+    apply {
+        tbl_0.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-action-selector-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-action-selector-midend.p4
@@ -1,0 +1,102 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct main_metadata_t {
+    bit<16> data;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("MainControlImpl.as") ActionSelector(PNA_HashAlgorithm_t.TARGET_DEFAULT, 32w1024, 32w16) as_0;
+    @name("MainControlImpl.a1") action a1(@name("param") bit<48> param) {
+        hdr.ethernet.dstAddr = param;
+    }
+    @name("MainControlImpl.a2") action a2(@name("param") bit<16> param_2) {
+        hdr.ethernet.etherType = param_2;
+    }
+    @name("MainControlImpl.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+            user_meta.data      : selector @name("user_meta.data") ;
+        }
+        actions = {
+            NoAction_1();
+            a1();
+            a2();
+        }
+        pna_implementation = as_0;
+        default_action = NoAction_1();
+    }
+    apply {
+        tbl_0.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    @hidden action pnaactionselector130() {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_pnaactionselector130 {
+        actions = {
+            pnaactionselector130();
+        }
+        const default_action = pnaactionselector130();
+    }
+    apply {
+        tbl_pnaactionselector130.apply();
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-action-selector.p4
+++ b/testdata/p4_16_samples_outputs/pna-action-selector.p4
@@ -1,0 +1,90 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct main_metadata_t {
+    bit<16> data;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    ActionSelector(PNA_HashAlgorithm_t.TARGET_DEFAULT, 32w1024, 32w16) as;
+    action a1(bit<48> param) {
+        hdr.ethernet.dstAddr = param;
+    }
+    action a2(bit<16> param) {
+        hdr.ethernet.etherType = param;
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact;
+            user_meta.data      : selector;
+        }
+        actions = {
+            NoAction;
+            a1;
+            a2;
+        }
+        pna_implementation = as;
+    }
+    apply {
+        tbl.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-action-selector.p4-error
+++ b/testdata/p4_16_samples_outputs/pna-action-selector.p4-error
@@ -1,0 +1,12 @@
+pna.p4(373): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+pna.p4(380): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^
+pna.p4(673): [--Wwarn=unused] warning: 'PM' is unused
+parser MainParserT<PM, MH, MM>(
+                   ^^
+pna.p4(680): [--Wwarn=unused] warning: 'PM' is unused
+control MainControlT<PM, MH, MM>(
+                     ^^

--- a/testdata/p4_16_samples_outputs/pna-action-selector.p4-stderr
+++ b/testdata/p4_16_samples_outputs/pna-action-selector.p4-stderr
@@ -1,0 +1,12 @@
+pna.p4(373): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+pna.p4(380): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^
+pna.p4(673): [--Wwarn=unused] warning: 'PM' is unused
+parser MainParserT<PM, MH, MM>(
+                   ^^
+pna.p4(680): [--Wwarn=unused] warning: 'PM' is unused
+control MainControlT<PM, MH, MM>(
+                     ^^

--- a/testdata/p4_16_samples_outputs/pna-action-selector.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-action-selector.p4.spec
@@ -1,0 +1,139 @@
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<4> version
+	bit<4> ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<3> flags
+	bit<13> fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+}
+
+struct a1_arg_t {
+	bit<48> param
+}
+
+struct a2_arg_t {
+	bit<16> param
+}
+
+struct tbl_set_group_id_arg_t {
+	bit<32> group_id
+}
+
+struct main_metadata_t {
+	bit<32> pna_pre_input_metadata_input_port
+	bit<16> pna_pre_input_metadata_parser_error
+	bit<32> pna_pre_input_metadata_direction
+	bit<3> pna_pre_input_metadata_pass
+	bit<8> pna_pre_input_metadata_loopedback
+	bit<8> pna_pre_output_metadata_decrypt
+	bit<32> pna_pre_output_metadata_said
+	bit<16> pna_pre_output_metadata_decrypt_start_offset
+	bit<32> pna_main_parser_input_metadata_direction
+	bit<3> pna_main_parser_input_metadata_pass
+	bit<8> pna_main_parser_input_metadata_loopedback
+	bit<32> pna_main_parser_input_metadata_input_port
+	bit<32> pna_main_input_metadata_direction
+	bit<3> pna_main_input_metadata_pass
+	bit<8> pna_main_input_metadata_loopedback
+	bit<64> pna_main_input_metadata_timestamp
+	bit<16> pna_main_input_metadata_parser_error
+	bit<8> pna_main_input_metadata_class_of_service
+	bit<32> pna_main_input_metadata_input_port
+	bit<8> pna_main_output_metadata_class_of_service
+	bit<16> local_metadata_data
+	bit<32> pna_main_output_metadata_output_port
+	bit<32> MainControlT_as_group_id
+	bit<32> MainControlT_as_member_id
+}
+metadata instanceof main_metadata_t
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+
+action NoAction args none {
+	return
+}
+
+action a1 args instanceof a1_arg_t {
+	mov h.ethernet.dstAddr t.param
+	return
+}
+
+action a2 args instanceof a2_arg_t {
+	mov h.ethernet.etherType t.param
+	return
+}
+
+action tbl_set_group_id args instanceof tbl_set_group_id_arg_t {
+	mov m.MainControlT_as_group_id t.group_id
+	return
+}
+
+table tbl {
+	key {
+		h.ethernet.srcAddr exact
+	}
+	actions {
+		tbl_set_group_id
+		NoAction
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+table as {
+	key {
+		m.MainControlT_as_member_id exact
+	}
+	actions {
+		NoAction
+		a1
+		a2
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+selector as_sel {
+	group_id m.MainControlT_as_group_id
+	selector {
+		m.local_metadata_data
+	}
+	member_id m.MainControlT_as_member_id
+	n_groups_max 1024
+	n_members_per_group_max 65536
+}
+
+apply {
+	rx m.pna_main_input_metadata_input_port
+	extract h.ethernet
+	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	MAINPARSERIMPL_ACCEPT :	mov m.MainControlT_as_member_id 0x0
+	mov m.MainControlT_as_group_id 0x0
+	table tbl
+	table as_sel
+	table as
+	emit h.ethernet
+	emit h.ipv4
+	tx m.pna_main_output_metadata_output_port
+}
+
+


### PR DESCRIPTION
This PR fixes action selector and action profile related table generation for DPDK backend.
The Action selector and action profile support was already available. However, it was referring to hard code table property "psa_implementation".  This PR updates it to pick the table property name based on architecture, thus enabling correct code generation for Action selector used in PNA program.

Changes include:
- Fix to pick the table property based on architecture.
- New test and reference outputs for PNA program using action selector