### PR TITLE
DPDK Backend: Move learn instructions constant argument to metadata

### DIFF
--- a/backends/dpdk/dpdkHelpers.cpp
+++ b/backends/dpdk/dpdkHelpers.cpp
@@ -761,7 +761,7 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
                 auto argument = param->to<IR::StructExpression>()->components.at(0)->expression;
                 add_instr(new IR::DpdkLearnStatement(action_name, argument));
             } else if (param->is<IR::Constant>()) {
-                // Mov constant param to metadata as DPDK expects it to be in metadata
+                // Move constant param to metadata as DPDK expects it to be in metadata
                 BUG_CHECK(metadataStruct, "Metadata structure missing unexpectedly!");
                 IR::ID learnArg(refmap->newName("learnArg"));
                 metadataStruct->fields.push_back(new IR::StructField(learnArg, param->type));
@@ -791,7 +791,7 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
                 return false;
             }
 
-            // Mov slot id and session id to metadata fields as DPDK expects these parameters
+            // Move slot id and session id to metadata fields as DPDK expects these parameters
             // to be in metadata
             BUG_CHECK(metadataStruct, "Metadata structure missing unexpectedly!");
             IR::ID slotName(refmap->newName("mirrorSlot"));

--- a/backends/dpdk/dpdkHelpers.cpp
+++ b/backends/dpdk/dpdkHelpers.cpp
@@ -761,7 +761,13 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
                 auto argument = param->to<IR::StructExpression>()->components.at(0)->expression;
                 add_instr(new IR::DpdkLearnStatement(action_name, argument));
             } else if (param->is<IR::Constant>()) {
-                add_instr(new IR::DpdkLearnStatement(action_name, param));
+                // Mov constant param to metadata as DPDK expects it to be in metadata
+                BUG_CHECK(metadataStruct, "Metadata structure missing unexpectedly!");
+                IR::ID learnArg(refmap->newName("learnArg"));
+                metadataStruct->fields.push_back(new IR::StructField(learnArg, param->type));
+                auto learnMember = new IR::Member(new IR::PathExpression("m"), learnArg);
+                add_instr(new IR::DpdkMovStatement(learnMember, param));
+                add_instr(new IR::DpdkLearnStatement(action_name, learnMember));
             } else {
                 ::error("%1%: unhandled function", s);
             }

--- a/testdata/p4_16_samples_outputs/pna-add-on-miss.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-add-on-miss.p4.spec
@@ -32,6 +32,7 @@ struct main_metadata_t {
 	bit<32> pna_main_output_metadata_output_port
 	bit<32> MainControlT_tmp
 	bit<32> MainControlT_tmp_0
+	bit<32> learnArg
 }
 metadata instanceof main_metadata_t
 
@@ -44,7 +45,8 @@ action next_hop args instanceof next_hop_arg_t {
 }
 
 action add_on_miss_action args none {
-	learn next_hop 0x0
+	mov m.learnArg 0x0
+	learn next_hop m.learnArg
 	return
 }
 

--- a/testdata/p4_16_samples_outputs/pna-dpdk-parser-state-err.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-parser-state-err.p4.spec
@@ -60,6 +60,7 @@ struct main_metadata_t {
 	bit<32> MainControlT_tmp_1
 	bit<32> MainControlT_tmp_2
 	bit<32> MainControlT_tmp_3
+	bit<32> learnArg
 }
 metadata instanceof main_metadata_t
 
@@ -85,7 +86,8 @@ action next_hop args instanceof next_hop_arg_t {
 }
 
 action add_on_miss_action args none {
-	learn next_hop 0x0
+	mov m.learnArg 0x0
+	learn next_hop m.learnArg
 	return
 }
 

--- a/testdata/p4_16_samples_outputs/pna-mux-dismantle.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-mux-dismantle.p4.spec
@@ -60,6 +60,7 @@ struct main_metadata_t {
 	bit<32> MainControlT_tmp_2
 	bit<32> MainControlT_tmp_3
 	bit<32> MainControlT_tmp_4
+	bit<32> learnArg
 }
 metadata instanceof main_metadata_t
 
@@ -85,7 +86,8 @@ action next_hop args instanceof next_hop_arg_t {
 }
 
 action add_on_miss_action args none {
-	learn next_hop 0x0
+	mov m.learnArg 0x0
+	learn next_hop m.learnArg
 	return
 }
 


### PR DESCRIPTION
This is a simple fix to move constant arguments for learn instruction to metadata. This is because DPDK target expects the operand to be in metadata.