### PR TITLE
Fix Context json to emit target_action_name and NoAction

### DIFF
--- a/backends/dpdk/DPDK_context_schema.json
+++ b/backends/dpdk/DPDK_context_schema.json
@@ -24,7 +24,11 @@
          "properties": {
             "action_name": {
                "type": "string",
-               "description": "Name of the action"
+               "description": "Name of the action as in P4 file"
+            },
+            "target_action_name": {
+               "type": "string",
+               "description": "Name of the action as in spec file"
             },
             "action_handle": {
                "type": "integer",

--- a/backends/dpdk/dpdkContext.cpp
+++ b/backends/dpdk/dpdkContext.cpp
@@ -221,9 +221,15 @@ DpdkContextGenerator::addMatchAttributes(const IR::P4Table*table, const cstring 
         auto* oneAction = new Util::JsonObject();
         struct actionAttributes attr = ::get(actionAttrMap, action->getName());
         auto actName = toStr(action->expression);
-        if (actName != "NoAction")
+        auto name = action->externalName();
+        if (name != "NoAction") {
             actName = ctrlName + "." + actName;
-        oneAction->emplace("action_name", actName);
+            name = ctrlName + "." + name;
+        } else {
+            actName = name;
+        }
+        oneAction->emplace("action_name", name);
+        oneAction->emplace("target_action_name", actName);
         oneAction->emplace("action_handle", attr.actionHandle);
         auto* immFldArray = new Util::JsonArray();
         if (attr.params) {
@@ -271,7 +277,7 @@ const IR::P4Table * table, const cstring controlName, bool isMatch) {
         // Printing compiler added actions is curently not required
         if (!attr.is_compiler_added_action) {
             auto *act = new Util::JsonObject();
-            auto actName = toStr(action->expression);
+            auto actName = action->externalName();
 
             // NoAction is not prefixed with control block name
             if (actName != "NoAction")


### PR DESCRIPTION
For some actions, the compiler frontend modifies the originalName of an action to uniquify the names.
This causes a mismatch between the action name in the action definition and in the table's action list causing the dpdk backend to optimize away some actions as unused which were actually being used.
The fix for the above issue was to use internal name instead of originalName. 

However, this causes a mismatch between action names in bfrt json and spec file. The context json  needs the name to be same in both bfrt and spec file, hence the bfswitchd reference application fails.

After analysis and discussion in public group (https://github.com/p4lang/p4c/issues/3171) and with SDE team,  concluded to add a new context json field to hold the name in spec file. The pipe manager can use this field to get the action ID from the spec file.

Since context json files are not part of the repository, attaching the diff patch for context json after fix and bfrt.json and spec file
[pna-example-tunnel.p4.bfrt.json.txt](https://github.com/usha1830/p4c/files/8477865/pna-example-tunnel.p4.bfrt.json.txt)
[pna-example-tunnel.p4.spec.txt](https://github.com/usha1830/p4c/files/8477866/pna-example-tunnel.p4.spec.txt)
[Report.txt](https://github.com/usha1830/p4c/files/8477874/Report.txt)



**Reference**:  
https://jira.devtools.intel.com/browse/NVFMSA-3358
https://github.com/p4lang/p4c/issues/3171
