### PR TITLE
Add support for generating tdi.json

### DIFF
--- a/backends/dpdk/control-plane/bfruntime_ext.cpp
+++ b/backends/dpdk/control-plane/bfruntime_ext.cpp
@@ -213,7 +213,25 @@ const Util::JsonObject*
 BFRuntimeSchemaGenerator::genSchema() const {
     auto* json = new Util::JsonObject();
 
-    json->emplace("schema_version", cstring("1.0.0"));
+    if (isTDI) {
+        cstring progName =  options.file;
+        auto fileName = progName.findlast('/');
+        // Handle the case when input file is in the current working directory.
+        // fileName would be null in that case, hence progName should remain unchanged.
+        if (fileName)
+            progName = fileName;
+        auto fileext = progName.find(".");
+        progName = progName.replace(fileext, "");
+        progName = progName.trim("/\t\n\r");
+        json->emplace("program_name", progName);
+        json->emplace("build_date", cstring(options.getBuildDate()));
+        json->emplace("compile_command", cstring(options.getCompileCommand()));
+        json->emplace("compiler_version", cstring(options.compilerVersion));
+        json->emplace("schema_version", cstring("0.1"));
+        json->emplace("target", cstring("DPDK"));
+    } else {
+        json->emplace("schema_version", cstring("1.0.0"));
+    }
 
     auto* tablesJson = new Util::JsonArray();
     json->emplace("tables", tablesJson);

--- a/backends/dpdk/control-plane/bfruntime_ext.h
+++ b/backends/dpdk/control-plane/bfruntime_ext.h
@@ -16,9 +16,9 @@ limitations under the License.
 #ifndef DPDK_CONTROL_PLANE_BFRUNTIME_EXT_H_
 #define DPDK_CONTROL_PLANE_BFRUNTIME_EXT_H_
 
+#include "backends/dpdk/options.h"
 #include "control-plane/bfruntime.h"
 #include "p4/config/dpdk/p4info.pb.h"
-
 namespace P4 {
 
 namespace BFRT {
@@ -27,13 +27,16 @@ namespace BFRT {
 /// the context of P4Runtime to the BF-RT info JSON used by the BF-RT API.
 class BFRuntimeSchemaGenerator : public BFRuntimeGenerator {
  public:
-    explicit BFRuntimeSchemaGenerator(const p4configv1::P4Info& p4info)
-        : BFRuntimeGenerator(p4info) { }
+    BFRuntimeSchemaGenerator(const p4configv1::P4Info& p4info, bool isTDI,
+        DPDK::DpdkOptions &options)
+        : BFRuntimeGenerator(p4info), isTDI(isTDI), options(options) { }
 
     /// Generates the schema as a Json object for the provided P4Info instance.
     const Util::JsonObject* genSchema() const override;
 
  private:
+    bool isTDI;
+    DPDK::DpdkOptions &options;
     // TODO(antonin): these values may need to be available to the BF-RT
     // implementation as well, if they want to expose them as enums.
 

--- a/backends/dpdk/main.cpp
+++ b/backends/dpdk/main.cpp
@@ -107,11 +107,30 @@ int main(int argc, char *const argv[]) {
             p4RuntimeSerializer->registerArch("pna",
                 new P4::ControlPlaneAPI::Standard::PNAArchHandlerBuilderForDPDK());
         auto p4Runtime = P4::generateP4Runtime(program, options.arch);
-        auto p4rt = new P4::BFRT::BFRuntimeSchemaGenerator(*p4Runtime.p4Info);
+        auto p4rt = new P4::BFRT::BFRuntimeSchemaGenerator(*p4Runtime.p4Info, false, options);
         std::ostream* out = openFile(options.bfRtSchema, false);
         if (!out) {
             ::error(ErrorType::ERR_IO,
                     "Could not open BF-RT schema file: %1%", options.bfRtSchema);
+            return 1;
+        }
+        p4rt->serializeBFRuntimeSchema(out);
+    }
+
+    if (!options.tdiFile.isNullOrEmpty()) {
+        auto p4RuntimeSerializer = P4::P4RuntimeSerializer::get();
+        if (options.arch == "psa")
+            p4RuntimeSerializer->registerArch("psa",
+                new P4::ControlPlaneAPI::Standard::PSAArchHandlerBuilderForDPDK());
+        if (options.arch == "pna")
+            p4RuntimeSerializer->registerArch("pna",
+                new P4::ControlPlaneAPI::Standard::PNAArchHandlerBuilderForDPDK());
+        auto p4Runtime = P4::generateP4Runtime(program, options.arch);
+        auto p4rt = new P4::BFRT::BFRuntimeSchemaGenerator(*p4Runtime.p4Info, true, options);
+        std::ostream* out = openFile(options.tdiFile, false);
+        if (!out) {
+            ::error(ErrorType::ERR_IO,
+                    "Could not open TDI Json file: %1%", options.tdiFile);
             return 1;
         }
         p4rt->serializeBFRuntimeSchema(out);

--- a/backends/dpdk/main.cpp
+++ b/backends/dpdk/main.cpp
@@ -39,6 +39,27 @@ limitations under the License.
 #include "lib/log.h"
 #include "lib/nullstream.h"
 
+void generateTDIBfrtJson(bool isTDI, const IR::P4Program *program, DPDK::DpdkOptions &options) {
+    auto p4RuntimeSerializer = P4::P4RuntimeSerializer::get();
+    if (options.arch == "psa")
+        p4RuntimeSerializer->registerArch("psa",
+            new P4::ControlPlaneAPI::Standard::PSAArchHandlerBuilderForDPDK());
+    if (options.arch == "pna")
+        p4RuntimeSerializer->registerArch("pna",
+            new P4::ControlPlaneAPI::Standard::PNAArchHandlerBuilderForDPDK());
+    auto p4Runtime = P4::generateP4Runtime(program, options.arch);
+
+    cstring filename = isTDI ? options.tdiFile : options.bfRtSchema;
+    auto p4rt = new P4::BFRT::BFRuntimeSchemaGenerator(*p4Runtime.p4Info, isTDI, options);
+    std::ostream* out = openFile(filename, false);
+    if (!out) {
+        ::error(ErrorType::ERR_IO,
+                "Could not open file: %1%", filename);
+        return;
+    }
+    p4rt->serializeBFRuntimeSchema(out);
+}
+
 int main(int argc, char *const argv[]) {
     setup_gc_logging();
 
@@ -99,42 +120,14 @@ int main(int argc, char *const argv[]) {
         return 1;
 
     if (!options.bfRtSchema.isNullOrEmpty()) {
-        auto p4RuntimeSerializer = P4::P4RuntimeSerializer::get();
-        if (options.arch == "psa")
-            p4RuntimeSerializer->registerArch("psa",
-                new P4::ControlPlaneAPI::Standard::PSAArchHandlerBuilderForDPDK());
-        if (options.arch == "pna")
-            p4RuntimeSerializer->registerArch("pna",
-                new P4::ControlPlaneAPI::Standard::PNAArchHandlerBuilderForDPDK());
-        auto p4Runtime = P4::generateP4Runtime(program, options.arch);
-        auto p4rt = new P4::BFRT::BFRuntimeSchemaGenerator(*p4Runtime.p4Info, false, options);
-        std::ostream* out = openFile(options.bfRtSchema, false);
-        if (!out) {
-            ::error(ErrorType::ERR_IO,
-                    "Could not open BF-RT schema file: %1%", options.bfRtSchema);
-            return 1;
-        }
-        p4rt->serializeBFRuntimeSchema(out);
+        generateTDIBfrtJson(false, program, options);
+    }
+    if (!options.tdiFile.isNullOrEmpty()) {
+        generateTDIBfrtJson(true, program, options);
     }
 
-    if (!options.tdiFile.isNullOrEmpty()) {
-        auto p4RuntimeSerializer = P4::P4RuntimeSerializer::get();
-        if (options.arch == "psa")
-            p4RuntimeSerializer->registerArch("psa",
-                new P4::ControlPlaneAPI::Standard::PSAArchHandlerBuilderForDPDK());
-        if (options.arch == "pna")
-            p4RuntimeSerializer->registerArch("pna",
-                new P4::ControlPlaneAPI::Standard::PNAArchHandlerBuilderForDPDK());
-        auto p4Runtime = P4::generateP4Runtime(program, options.arch);
-        auto p4rt = new P4::BFRT::BFRuntimeSchemaGenerator(*p4Runtime.p4Info, true, options);
-        std::ostream* out = openFile(options.tdiFile, false);
-        if (!out) {
-            ::error(ErrorType::ERR_IO,
-                    "Could not open TDI Json file: %1%", options.tdiFile);
-            return 1;
-        }
-        p4rt->serializeBFRuntimeSchema(out);
-    }
+    if (::errorCount() > 0)
+        return 1;
 
     DPDK::DpdkMidEnd midEnd(options);
     midEnd.addDebugHook(hook);

--- a/backends/dpdk/options.h
+++ b/backends/dpdk/options.h
@@ -26,6 +26,8 @@ class DpdkOptions : public CompilerOptions {
     cstring bfRtSchema = "";
     // file to output to
     cstring outputFile = nullptr;
+    // file to ouput TDI Json to
+    cstring tdiFile = "";
     // file to ouput context Json to
     cstring ctxtFile = "";
     // read from json
@@ -57,6 +59,9 @@ class DpdkOptions : public CompilerOptions {
         registerOption("-o", "outfile",
                 [this](const char* arg) { outputFile = arg; return true; },
                 "Write output to outfile");
+        registerOption("--tdi", "file",
+                [this](const char *arg) { tdiFile = arg; return true; },
+                "Generate and write TDI JSON to the specified file");
         registerOption("--context", "file",
                 [this](const char *arg) { ctxtFile = arg; return true; },
                 "Generate and write context JSON to the specified file");


### PR DESCRIPTION

Tdi json file needs to be emitted from p4c-dpdk. The contents of tdi json file is same as bfrt json with few additional program/environment related fields given below
{
"program_name" : "counter",
"build_date" : "Tue May 10 23:00:18 2022",
"compile_command" : "/root/p4c/p4c/build/p4c-dpdk -I /root/p4c/p4c/build/p4include --p4v=16 --p4runtime-files ./p4Info.txt -I /root/p4c/p4c/build/p4include/dpdk -o ./pipe/counter1.spec --arch psa --bf-rt-schema ./bf-rt.json --context ./pipe/context.json counter.p4",
"compiler_version" : "0.1 (SHA: 362c2dbf2 BUILD: RELEASE)",
"schema_version" : "0.1",
"target" : "DPDK",
<< bfrt json contents >>
}
Attached sample tdi json and corresponding bfrt json.

[bfrt.json.txt](https://github.com/usha1830/p4c/files/8992498/bfrt.json.txt)
[psa-example-mask-range.p4.txt](https://github.com/usha1830/p4c/files/8992500/psa-example-mask-range.p4.txt)
[tdi.json.txt](https://github.com/usha1830/p4c/files/8992501/tdi.json.txt)
