### PR TITLE
Fix Missing metadata for temporary variables added for Mask operation

### DIFF
--- a/backends/dpdk/dpdkProgram.cpp
+++ b/backends/dpdk/dpdkProgram.cpp
@@ -292,8 +292,8 @@ void ConvertToDpdkParser::getCondVars(const IR::Expression *sv, const IR::Expres
         unsigned value = right->to<IR::Constant>()->asUnsigned() &
                          left->to<IR::Constant>()->asUnsigned();
         auto tmpDecl = addNewTmpVarToMetadata("tmpMask", sv->type);
-        auto tmpMask = new IR::PathExpression(
-                           IR::ID("m." + tmpDecl->name.name));
+        auto tmpMask = new IR::Member(new IR::PathExpression(IR::ID("m")),
+                                      IR::ID(tmpDecl->name.name));
         structure->push_variable(new IR::DpdkDeclaration(tmpDecl));
         add_instr(new IR::DpdkMovStatement(tmpMask, sv));
         add_instr(new IR::DpdkAndStatement(tmpMask, tmpMask, right));

--- a/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-1.p4.spec
@@ -58,6 +58,8 @@ struct metadata {
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<16> local_metadata_data
 	bit<8> Ingress_err
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof metadata
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2.p4.spec
@@ -59,6 +59,8 @@ struct metadata {
 	bit<16> local_metadata_data
 	bit<8> IngressParser_parser_tmp
 	bit<8> Ingress_err
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof metadata
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-errorcode.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-errorcode.p4.spec
@@ -58,6 +58,8 @@ struct metadata {
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<16> local_metadata_data
 	bit<8> Ingress_hasReturned
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof metadata
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err4.p4.spec
@@ -59,6 +59,8 @@ struct metadata {
 	bit<16> local_metadata_data
 	bit<48> ingress_tbl_ethernet_srcAddr
 	bit<16> ingress_tbl_ipv4_totalLen
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof metadata
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err5.p4.spec
@@ -60,6 +60,8 @@ struct metadata {
 	bit<48> ingress_tbl_ethernet_srcAddr
 	bit<48> ingress_tbl_ethernet_dstAddr
 	bit<8> Ingress_key
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof metadata
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-valid.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-valid.p4.spec
@@ -57,6 +57,8 @@ struct metadata {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<16> local_metadata_data
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof metadata
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if-1.p4.spec
@@ -76,6 +76,8 @@ struct user_meta_t {
 	bit<16> local_metadata_data1
 	bit<48> MyIC_tbl_ethernet_srcAddr
 	bit<48> MyIC_foo_ethernet_dstAddr
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof user_meta_t
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if.p4.spec
@@ -67,6 +67,8 @@ struct user_meta_t {
 	bit<16> local_metadata_data
 	bit<16> local_metadata_data1
 	bit<48> MyIC_tbl_ethernet_srcAddr
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof user_meta_t
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-1.p4.spec
@@ -60,6 +60,8 @@ struct metadata {
 	bit<48> ingress_tbl_ethernet_srcAddr
 	bit<48> ingress_tbl_ethernet_dstAddr
 	bit<8> Ingress_key
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof metadata
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-2.p4.spec
@@ -60,6 +60,8 @@ struct metadata {
 	bit<48> ingress_tbl_ethernet_srcAddr
 	bit<48> ingress_tbl_ethernet_dstAddr
 	bit<8> Ingress_key
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof metadata
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-3.p4.spec
@@ -58,6 +58,8 @@ struct metadata {
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<16> local_metadata_data
 	bit<8> Ingress_key
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof metadata
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys.p4.spec
@@ -60,6 +60,8 @@ struct metadata {
 	bit<48> ingress_tbl_ethernet_srcAddr
 	bit<48> ingress_tbl_ethernet_dstAddr
 	bit<8> Ingress_key
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof metadata
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-switch.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-switch.p4.spec
@@ -66,6 +66,8 @@ struct user_meta_t {
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<16> local_metadata_data
 	bit<48> MyIC_tbl_ethernet_srcAddr
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof user_meta_t
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid1.p4.spec
@@ -60,6 +60,8 @@ struct metadata {
 	bit<8> ingress_tbl_ethernet_isValid
 	bit<48> ingress_tbl_ethernet_dstAddr
 	bit<48> ingress_tbl_ethernet_srcAddr
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof metadata
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid2.p4.spec
@@ -62,6 +62,8 @@ struct metadata {
 	bit<8> Ingress_tmp
 	bit<8> Ingress_tmp_0
 	bit<8> Ingress_key
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof metadata
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid3.p4.spec
@@ -64,6 +64,8 @@ struct metadata {
 	bit<8> Ingress_tmp_1
 	bit<8> Ingress_tmp_2
 	bit<8> Ingress_key
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof metadata
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid4.p4.spec
@@ -64,6 +64,8 @@ struct metadata {
 	bit<8> Ingress_tmp_1
 	bit<8> Ingress_tmp_2
 	bit<8> Ingress_key
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof metadata
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid5.p4.spec
@@ -61,6 +61,8 @@ struct metadata {
 	bit<48> ingress_tbl_ethernet_srcAddr
 	bit<8> Ingress_tmp
 	bit<8> Ingress_key
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof metadata
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid6.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid6.p4.spec
@@ -63,6 +63,8 @@ struct metadata {
 	bit<8> Ingress_tmp_0
 	bit<8> Ingress_tmp_1
 	bit<8> Ingress_key
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof metadata
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid7.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid7.p4.spec
@@ -60,6 +60,8 @@ struct metadata {
 	bit<8> ingress_tbl_ethernet_isValid
 	bit<8> ingress_tbl_tcp_isValid
 	bit<8> ingress_tbl_ipv4_isValid
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof metadata
 

--- a/testdata/p4_16_samples_outputs/psa-example-mask-range.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-mask-range.p4.spec
@@ -56,6 +56,8 @@ struct metadata {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<16> local_metadata_data
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof metadata
 

--- a/testdata/p4_16_samples_outputs/psa-example-mask-range1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-mask-range1.p4.spec
@@ -57,6 +57,8 @@ struct metadata {
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<16> local_metadata_data
 	bit<16> Ingress_tmpMask
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof metadata
 

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple-1.p4.spec
@@ -55,6 +55,7 @@ struct metadata {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<16> local_metadata_data
+	bit<16> tmpMask
 }
 metadata instanceof metadata
 

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple-mask.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple-mask.p4.spec
@@ -56,6 +56,8 @@ struct metadata {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<16> local_metadata_data
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof metadata
 

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple-wc.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple-wc.p4.spec
@@ -55,6 +55,7 @@ struct metadata {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<16> local_metadata_data
+	bit<8> tmpMask
 }
 metadata instanceof metadata
 

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple.p4.spec
@@ -55,6 +55,7 @@ struct metadata {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<16> local_metadata_data
+	bit<8> tmpMask
 }
 metadata instanceof metadata
 

--- a/testdata/p4_16_samples_outputs/psa-switch-expression-without-default.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-switch-expression-without-default.p4.spec
@@ -67,6 +67,8 @@ struct user_meta_t {
 	bit<16> local_metadata_data
 	bit<48> MyIC_tbl_ethernet_srcAddr
 	bit<16> Ingress_tmp
+	bit<16> tmpMask
+	bit<8> tmpMask_0
 }
 metadata instanceof user_meta_t
 


### PR DESCRIPTION
The unused metadata elimination pass removes some of the used metadata variables created for Mask operation.
Metadata elimination pass works on Member type node and these variables are created as PathExpressions, hence these were also eliminated.

Changing these to be added as Member  resolves the issue.