### PR TITLE
Fix action param processing for context json

### DIFF
--- a/backends/dpdk/dpdkContext.cpp
+++ b/backends/dpdk/dpdkContext.cpp
@@ -242,7 +242,7 @@ void DpdkContextGenerator::setActionAttributes(const IR::P4Table *tbl) {
 
         /* DPDK target takes a structure as parameter for Actions. So, all action
            parameters are collected into a structure by an earlier pass. */
-        auto params = ::get(structure->args_struct_map, act->externalName() + "_arg_t");
+        auto params = ::get(structure->args_struct_map, act->getPath()->name.name + "_arg_t");
         if (params)
             attr.params = params->clone();
         else


### PR DESCRIPTION
Rootcause: The argument map was looked up with external name where the insertion happens using the internal name.
[context_orig.json.txt](https://github.com/usha1830/p4c/files/9429782/context.json.txt)
[context_fixed.json.txt](https://github.com/usha1830/p4c/files/9429784/context1.json.txt)
[srv6.p4.txt](https://github.com/usha1830/p4c/files/9429785/srv6.p4.txt)
