### PR TITLE
Update default timeout values for learner table entries

### DIFF
--- a/backends/dpdk/constants.h
+++ b/backends/dpdk/constants.h
@@ -29,7 +29,8 @@ const unsigned dpdk_default_table_size = 65536;
 const unsigned dpdk_learner_max_configurable_timeout_values = 8;
 const unsigned default_learner_table_size = 0x10000;
 // default timeout values for learner table to support common protocol states
-const unsigned default_learner_table_timeout[] = {10, 30, 60, 120, 300, 43200, 120, 120};
+const unsigned default_learner_table_timeout[dpdk_learner_max_configurable_timeout_values] =
+                                            {10, 30, 60, 120, 300, 43200, 120, 120};
 
 // JSON schema versions
 const cstring bfrtSchemaVersion = "1.0.0";

--- a/backends/dpdk/constants.h
+++ b/backends/dpdk/constants.h
@@ -28,7 +28,8 @@ const unsigned dpdk_default_table_size = 65536;
 // Maximum number of configurable timeout values
 const unsigned dpdk_learner_max_configurable_timeout_values = 8;
 const unsigned default_learner_table_size = 0x10000;
-const unsigned default_learner_table_timeout = 120;
+// default timeout values for learner table to support common protocol states
+const unsigned default_learner_table_timeout[] = {10, 30, 60, 120, 300, 43200, 120, 120};
 
 // JSON schema versions
 const cstring bfrtSchemaVersion = "1.0.0";

--- a/backends/dpdk/spec.cpp
+++ b/backends/dpdk/spec.cpp
@@ -464,7 +464,7 @@ std::ostream& IR::DpdkLearner::toSpec(std::ostream& out) const {
     // This initializes 8 timeout values which can later be configured through control plane APIs.
     out << "\ttimeout {" << std::endl;
     for (unsigned int i = 0; i < dpdk_learner_max_configurable_timeout_values ; i++)
-        out << "\t\t" << std::dec << default_learner_table_timeout << std::endl;
+        out << "\t\t" << std::dec << default_learner_table_timeout[i] << std::endl;
     out << "\n\t\t}";
     out << "\n}" << std::endl;
     return out;

--- a/testdata/p4_16_samples_outputs/pna-add-on-miss.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-add-on-miss.p4.spec
@@ -77,12 +77,12 @@ learner ipv4_da {
 	default_action add_on_miss_action args none 
 	size 0x10000
 	timeout {
+		10
+		30
+		60
 		120
-		120
-		120
-		120
-		120
-		120
+		300
+		43200
 		120
 		120
 
@@ -100,12 +100,12 @@ learner ipv4_da2 {
 	default_action add_on_miss_action2 args none 
 	size 0x10000
 	timeout {
+		10
+		30
+		60
 		120
-		120
-		120
-		120
-		120
-		120
+		300
+		43200
 		120
 		120
 

--- a/testdata/p4_16_samples_outputs/pna-add_on_miss_action_name.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-add_on_miss_action_name.p4.spec
@@ -73,12 +73,12 @@ learner ct_ipv4_da {
 	default_action ct_add_on_miss_action_0 args none 
 	size 0x10000
 	timeout {
+		10
+		30
+		60
 		120
-		120
-		120
-		120
-		120
-		120
+		300
+		43200
 		120
 		120
 
@@ -96,12 +96,12 @@ learner ipv4_da {
 	default_action add_on_miss_action args none 
 	size 0x10000
 	timeout {
+		10
+		30
+		60
 		120
-		120
-		120
-		120
-		120
-		120
+		300
+		43200
 		120
 		120
 

--- a/testdata/p4_16_samples_outputs/pna-dpdk-parser-state-err.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-parser-state-err.p4.spec
@@ -126,12 +126,12 @@ learner ipv4_da {
 	default_action add_on_miss_action args none 
 	size 0x10000
 	timeout {
+		10
+		30
+		60
 		120
-		120
-		120
-		120
-		120
-		120
+		300
+		43200
 		120
 		120
 
@@ -151,12 +151,12 @@ learner ipv4_da2 {
 	default_action add_on_miss_action2 args none 
 	size 0x10000
 	timeout {
+		10
+		30
+		60
 		120
-		120
-		120
-		120
-		120
-		120
+		300
+		43200
 		120
 		120
 

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-use-annon.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-use-annon.p4.spec
@@ -78,12 +78,12 @@ learner ipv4_da {
 	default_action add_on_miss_action args none 
 	size 0x10000
 	timeout {
+		10
+		30
+		60
 		120
-		120
-		120
-		120
-		120
-		120
+		300
+		43200
 		120
 		120
 
@@ -101,12 +101,12 @@ learner ipv4_da2 {
 	default_action add_on_miss_action2 args none 
 	size 0x10000
 	timeout {
+		10
+		30
+		60
 		120
-		120
-		120
-		120
-		120
-		120
+		300
+		43200
 		120
 		120
 

--- a/testdata/p4_16_samples_outputs/pna-example-tcp-connection-tracking.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-tcp-connection-tracking.p4.spec
@@ -120,12 +120,12 @@ learner ct_tcp_table {
 	default_action ct_tcp_table_miss args none 
 	size 0x10000
 	timeout {
+		10
+		30
+		60
 		120
-		120
-		120
-		120
-		120
-		120
+		300
+		43200
 		120
 		120
 

--- a/testdata/p4_16_samples_outputs/pna-mux-dismantle.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-mux-dismantle.p4.spec
@@ -131,12 +131,12 @@ learner ipv4_da {
 	default_action add_on_miss_action args none 
 	size 0x10000
 	timeout {
+		10
+		30
+		60
 		120
-		120
-		120
-		120
-		120
-		120
+		300
+		43200
 		120
 		120
 
@@ -156,12 +156,12 @@ learner ipv4_da2 {
 	default_action add_on_miss_action2 args none 
 	size 0x10000
 	timeout {
+		10
+		30
+		60
 		120
-		120
-		120
-		120
-		120
-		120
+		300
+		43200
 		120
 		120
 


### PR DESCRIPTION
This PR updates the default timeout values for add_entry extern for add_on_miss tables. This would allow the user to avoid the runtime configuration in case of tcp connection tracking usecase.