### PR TITLE
Add set_member_id in action list for action selector

### DIFF
--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -849,7 +849,8 @@ class SplitP4TableCommon : public Transform {
     const IR::Node* postorder(IR::IfStatement*) override;
     const IR::Node* postorder(IR::SwitchStatement*) override;
 
-    std::tuple<const IR::P4Table*, cstring> create_match_table(const IR::P4Table* /* tbl */);
+    std::tuple<const IR::P4Table*, cstring, cstring>
+        create_match_table(const IR::P4Table* /* tbl */);
     const IR::P4Action* create_action(cstring /* actionName */, cstring /* id */, cstring);
     const IR::P4Table* create_member_table(const IR::P4Table*, cstring, cstring);
     const IR::P4Table* create_group_table(const IR::P4Table*, cstring, cstring, cstring, int, int);

--- a/testdata/p4_16_samples_outputs/pna-action-selector-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-action-selector-1.p4.spec
@@ -35,6 +35,10 @@ struct tbl_set_group_id_arg_t {
 	bit<32> group_id
 }
 
+struct tbl_set_member_id_arg_t {
+	bit<32> member_id
+}
+
 struct main_metadata_t {
 	bit<32> pna_main_input_metadata_input_port
 	bit<16> local_metadata_data
@@ -69,12 +73,18 @@ action tbl_set_group_id args instanceof tbl_set_group_id_arg_t {
 	return
 }
 
+action tbl_set_member_id args instanceof tbl_set_member_id_arg_t {
+	mov m.MainControlT_as_member_id t.member_id
+	return
+}
+
 table tbl {
 	key {
 		h.ethernet.srcAddr exact
 	}
 	actions {
 		tbl_set_group_id
+		tbl_set_member_id
 		set_exception
 	}
 	default_action set_exception args vport 0x0 const

--- a/testdata/p4_16_samples_outputs/pna-action-selector.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-action-selector.p4.spec
@@ -31,6 +31,10 @@ struct tbl_set_group_id_arg_t {
 	bit<32> group_id
 }
 
+struct tbl_set_member_id_arg_t {
+	bit<32> member_id
+}
+
 struct main_metadata_t {
 	bit<32> pna_main_input_metadata_input_port
 	bit<16> local_metadata_data
@@ -64,12 +68,18 @@ action tbl_set_group_id args instanceof tbl_set_group_id_arg_t {
 	return
 }
 
+action tbl_set_member_id args instanceof tbl_set_member_id_arg_t {
+	mov m.MainControlT_as_member_id t.member_id
+	return
+}
+
 table tbl {
 	key {
 		h.ethernet.srcAddr exact
 	}
 	actions {
 		tbl_set_group_id
+		tbl_set_member_id
 		NoAction
 	}
 	default_action NoAction args none 

--- a/testdata/p4_16_samples_outputs/psa-action-selector1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-selector1.p4.spec
@@ -38,6 +38,10 @@ struct tbl_set_group_id_arg_t {
 	bit<32> group_id
 }
 
+struct tbl_set_member_id_arg_t {
+	bit<32> member_id
+}
+
 struct user_meta_t {
 	bit<32> psa_ingress_input_metadata_ingress_port
 	bit<8> psa_ingress_output_metadata_drop
@@ -69,12 +73,18 @@ action tbl_set_group_id args instanceof tbl_set_group_id_arg_t {
 	return
 }
 
+action tbl_set_member_id args instanceof tbl_set_member_id_arg_t {
+	mov m.Ingress_as_member_id t.member_id
+	return
+}
+
 table tbl {
 	key {
 		h.ethernet.srcAddr exact
 	}
 	actions {
 		tbl_set_group_id
+		tbl_set_member_id
 		NoAction
 	}
 	default_action NoAction args none 

--- a/testdata/p4_16_samples_outputs/psa-action-selector2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-selector2.p4.spec
@@ -38,6 +38,10 @@ struct tbl_set_group_id_arg_t {
 	bit<32> group_id
 }
 
+struct tbl_set_member_id_arg_t {
+	bit<32> member_id
+}
+
 struct user_meta_t {
 	bit<32> psa_ingress_input_metadata_ingress_port
 	bit<8> psa_ingress_output_metadata_drop
@@ -70,12 +74,18 @@ action tbl_set_group_id args instanceof tbl_set_group_id_arg_t {
 	return
 }
 
+action tbl_set_member_id args instanceof tbl_set_member_id_arg_t {
+	mov m.Ingress_as_member_id t.member_id
+	return
+}
+
 table tbl {
 	key {
 		h.ethernet.srcAddr exact
 	}
 	actions {
 		tbl_set_group_id
+		tbl_set_member_id
 		NoAction
 	}
 	default_action NoAction args none 

--- a/testdata/p4_16_samples_outputs/psa-action-selector4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-selector4.p4.spec
@@ -38,6 +38,10 @@ struct tbl_set_group_id_arg_t {
 	bit<32> group_id
 }
 
+struct tbl_set_member_id_arg_t {
+	bit<32> member_id
+}
+
 struct user_meta_t {
 	bit<32> psa_ingress_input_metadata_ingress_port
 	bit<8> psa_ingress_output_metadata_drop
@@ -69,12 +73,18 @@ action tbl_set_group_id args instanceof tbl_set_group_id_arg_t {
 	return
 }
 
+action tbl_set_member_id args instanceof tbl_set_member_id_arg_t {
+	mov m.Ingress_as_member_id t.member_id
+	return
+}
+
 table tbl {
 	key {
 		h.ethernet.srcAddr exact
 	}
 	actions {
 		tbl_set_group_id
+		tbl_set_member_id
 		NoAction
 	}
 	default_action NoAction args none 

--- a/testdata/p4_16_samples_outputs/psa-action-selector5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-selector5.p4.spec
@@ -38,6 +38,10 @@ struct tbl_set_group_id_arg_t {
 	bit<32> group_id
 }
 
+struct tbl_set_member_id_arg_t {
+	bit<32> member_id
+}
+
 struct user_meta_t {
 	bit<32> psa_ingress_input_metadata_ingress_port
 	bit<8> psa_ingress_output_metadata_drop
@@ -69,12 +73,18 @@ action tbl_set_group_id args instanceof tbl_set_group_id_arg_t {
 	return
 }
 
+action tbl_set_member_id args instanceof tbl_set_member_id_arg_t {
+	mov m.Ingress_as_member_id t.member_id
+	return
+}
+
 table tbl {
 	key {
 		h.ethernet.srcAddr exact
 	}
 	actions {
 		tbl_set_group_id
+		tbl_set_member_id
 		NoAction
 	}
 	default_action NoAction args none 


### PR DESCRIPTION
From PSA specification: A table with an action action selector implementation consists of entries that point to either an action profile member reference or an action profile group reference. 
In DPDK backend implementation, we were handling only entries pointing to a group reference and not member reference. Added the support for member reference