### PR TITLE
Dpdk backend : Use vector to populate checksum struct

### DIFF
--- a/backends/dpdk/dpdkHelpers.cpp
+++ b/backends/dpdk/dpdkHelpers.cpp
@@ -338,9 +338,11 @@ bool ConvertStatementToDpdk::preorder(const IR::AssignmentStatement *a) {
                 if (e->method->getName().name == "get") {
                     auto res = structure->csum_map.find(
                         e->object->to<IR::Declaration_Instance>());
-                    cstring intermediate;
+                    cstring intermediate = "";
                     if (res != structure->csum_map.end()) {
                         intermediate = res->second;
+                    } else {
+                        BUG("checksum map does not collect all checksum def.");
                     }
                     i = new IR::DpdkGetChecksumStatement(
                         left, e->object->getName(), intermediate);
@@ -949,7 +951,7 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
         if (a->originalExternType->getName().name == "InternetChecksum") {
             auto res =
                 structure->csum_map.find(a->object->to<IR::Declaration_Instance>());
-            cstring intermediate;
+            cstring intermediate = "";
             if (res != structure->csum_map.end()) {
                 intermediate = res->second;
             } else {

--- a/testdata/p4_16_samples_outputs/psa-example-parser-checksum.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-parser-checksum.p4.spec
@@ -32,8 +32,8 @@ struct tcp_t {
 }
 
 struct cksum_state_t {
-	bit<16> state_1
 	bit<16> state_0
+	bit<16> state_1
 }
 
 struct psa_ingress_output_metadata_t {


### PR DESCRIPTION
Struct fields for csum state is being populated using  a map, which cause non deterministic output for tests having checksum.
Fixed by using a vector instead.