### PR TITLE
Fix context generation when both --context and --bf-rt-schema options are supplied

### DIFF
--- a/backends/dpdk/dpdkContext.h
+++ b/backends/dpdk/dpdkContext.h
@@ -167,6 +167,7 @@ class DpdkContextGenerator : public Inspector {
     void setActionAttributes(const IR::P4Table *table);
     void setDefaultActionHandle(const IR::P4Table *table);
     void CollectTablesAndSetAttributes();
+    cstring removePipePrefix(cstring);
 };
 
 }  // namespace DPDK


### PR DESCRIPTION
For bfrt.json, an additional pipe_name prefix is added to the table and extern names. 
Context json uses the table and action ids from p4info. Since the name of table is different when bfrt json is generated whereas when it is not generated, hence while generating context json, we remove the pipename prefix added by the bfrt generator.