### PR TITLE
Fix optional and range match kind and const entries attribute in bfrt and context json

### DIFF
--- a/backends/dpdk/control-plane/bfruntime_ext.cpp
+++ b/backends/dpdk/control-plane/bfruntime_ext.cpp
@@ -184,12 +184,25 @@ bool BFRuntimeSchemaGenerator::addActionProfIds(const p4configv1::Table &table,
     return true;
 }
 
+void BFRuntimeSchemaGenerator::addConstTableAttr(Util::JsonArray *) const {
+    // Intentionally empty function body to skip attribute addition for const entries
+    return;
+}
+
 void BFRuntimeSchemaGenerator::addActionProfs(Util::JsonArray *tablesJson) const {
     for (const auto &actionProf : p4info.action_profiles()) {
         auto actionProfInstance = ActionProf::from(p4info, actionProf);
         if (actionProfInstance == std::nullopt) continue;
         addActionProfCommon(tablesJson, *actionProfInstance);
     }
+}
+
+bool BFRuntimeSchemaGenerator::addMatchTypePriority(std::optional<cstring> &matchType) const {
+    if (*matchType == "Ternary" || *matchType == "Range" || *matchType == "Optional") {
+        *matchType = "Ternary";
+        return true;
+    }
+    return false;
 }
 
 std::optional<bool> BFRuntimeSchemaGenerator::actProfHasSelector(P4Id actProfId) const {

--- a/backends/dpdk/control-plane/bfruntime_ext.h
+++ b/backends/dpdk/control-plane/bfruntime_ext.h
@@ -66,6 +66,8 @@ class BFRuntimeSchemaGenerator : public BFRuntimeGenerator {
                                  const ActionSelector &actionProf) const;
     void addActionSelectorGetMemberCommon(Util::JsonArray *tablesJson,
                                           const ActionSelector &actionProf) const;
+    void addConstTableAttr(Util::JsonArray *attrJson) const override;
+    bool addMatchTypePriority(std::optional<cstring> &matchType) const override;
     void addActionProfs(Util::JsonArray *tablesJson) const override;
     bool addActionProfIds(const p4configv1::Table &table,
                           Util::JsonObject *tableJson) const override;

--- a/backends/dpdk/dpdkAsmOpt.h
+++ b/backends/dpdk/dpdkAsmOpt.h
@@ -199,7 +199,7 @@ class ShortenTokenLength : public Transform {
     static ordered_map<cstring, cstring> origNameMap;
 
     const IR::Node *preorder(IR::Member *m) override {
-        if (m->toString().startsWith("m."))
+        if (m->toString().startsWith("m.") || m->toString().startsWith("t."))
             m->member = shortenString(m->member);
         else
             m->member = shortenString(m->member, 30);

--- a/backends/dpdk/dpdkContext.cpp
+++ b/backends/dpdk/dpdkContext.cpp
@@ -172,7 +172,9 @@ void DpdkContextGenerator::addKeyField(Util::JsonArray *keyJson, const cstring n
     keyField->emplace("name", nameAnnotation);
     keyField->emplace("instance_name", instanceName);
     keyField->emplace("field_name", fieldName);
-    keyField->emplace("match_type", toStr(key->matchType));
+    auto match_kind = toStr(key->matchType);
+    if (match_kind == "optional" || match_kind == "range") match_kind = "ternary";
+    keyField->emplace("match_type", match_kind);
     keyField->emplace("start_bit", 0);
     keyField->emplace("bit_width", key->expression->type->width_bits());
     keyField->emplace("bit_width_full", key->expression->type->width_bits());

--- a/control-plane/bfruntime.h
+++ b/control-plane/bfruntime.h
@@ -383,6 +383,8 @@ class BFRuntimeGenerator {
     };
 
     void addMatchTables(Util::JsonArray *tablesJson) const;
+    virtual bool addMatchTypePriority(std::optional<cstring> &matchType) const;
+    virtual void addConstTableAttr(Util::JsonArray *attrJson) const;
     virtual void addActionProfs(Util::JsonArray *tablesJson) const;
     virtual bool addActionProfIds(const p4configv1::Table &table,
                                   Util::JsonObject *tableJson) const;

--- a/testdata/p4_16_pna_errors_outputs/pna-example-tcp-connection-tracking-err-1.p4.bfrt.json
+++ b/testdata/p4_16_pna_errors_outputs/pna-example-tcp-connection-tracking-err-1.p4.bfrt.json
@@ -59,7 +59,7 @@
       ],
       "data" : [],
       "supported_operations" : [],
-      "attributes" : ["EntryScope", "ConstTable"]
+      "attributes" : ["EntryScope"]
     },
     {
       "name" : "pipe.MainControlImpl.ct_tcp_table",

--- a/testdata/p4_16_pna_errors_outputs/pna-example-tcp-connection-tracking-err.p4.bfrt.json
+++ b/testdata/p4_16_pna_errors_outputs/pna-example-tcp-connection-tracking-err.p4.bfrt.json
@@ -59,7 +59,7 @@
       ],
       "data" : [],
       "supported_operations" : [],
-      "attributes" : ["EntryScope", "ConstTable"]
+      "attributes" : ["EntryScope"]
     },
     {
       "name" : "pipe.MainControlImpl.ct_tcp_table",

--- a/testdata/p4_16_samples_outputs/pna-example-dpdk-optional.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/pna-example-dpdk-optional.p4.bfrt.json
@@ -28,7 +28,7 @@
           "repeated" : false,
           "annotations" : [],
           "mandatory" : false,
-          "match_type" : "Optional",
+          "match_type" : "Ternary",
           "type" : {
             "type" : "bytes",
             "width" : 32

--- a/testdata/p4_16_samples_outputs/pna-example-tcp-connection-tracking.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/pna-example-tcp-connection-tracking.p4.bfrt.json
@@ -59,7 +59,7 @@
       ],
       "data" : [],
       "supported_operations" : [],
-      "attributes" : ["EntryScope", "ConstTable"]
+      "attributes" : ["EntryScope"]
     },
     {
       "name" : "pipe.MainControlImpl.ct_tcp_table",

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4.bfrt.json
@@ -77,7 +77,7 @@
       ],
       "data" : [],
       "supported_operations" : [],
-      "attributes" : ["EntryScope", "ConstTable"]
+      "attributes" : ["EntryScope"]
     }
   ],
   "learn_filters" : []

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid4.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid4.p4.bfrt.json
@@ -16,7 +16,7 @@
           "repeated" : false,
           "annotations" : [],
           "mandatory" : false,
-          "match_type" : "Optional",
+          "match_type" : "Ternary",
           "type" : {
             "type" : "bytes",
             "width" : 1

--- a/testdata/p4_16_samples_outputs/psa-example-optional-match.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-optional-match.p4.bfrt.json
@@ -16,7 +16,7 @@
           "repeated" : false,
           "annotations" : [],
           "mandatory" : false,
-          "match_type" : "Optional",
+          "match_type" : "Ternary",
           "type" : {
             "type" : "bytes",
             "width" : 48

--- a/testdata/p4_16_samples_outputs/psa-example-parser-checksum.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-parser-checksum.p4.bfrt.json
@@ -62,7 +62,7 @@
         }
       ],
       "supported_operations" : ["SyncCounters"],
-      "attributes" : ["EntryScope", "ConstTable"]
+      "attributes" : ["EntryScope"]
     }
   ],
   "learn_filters" : []

--- a/testdata/p4_16_samples_outputs/psa-example-range-match.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-range-match.p4.bfrt.json
@@ -16,7 +16,7 @@
           "repeated" : false,
           "annotations" : [],
           "mandatory" : false,
-          "match_type" : "Range",
+          "match_type" : "Ternary",
           "type" : {
             "type" : "bytes",
             "width" : 48


### PR DESCRIPTION
1) Optional and range match kind changed to Ternary in bfrt and context json as the DPDK target doesn't support these match kinds 2) Disable emitting ConstTable attribute in bfrt.json for tables with const entries as it is not supported by the control plane software (p4-dpdk-target). 3) Fix name shortening for action parameters