### PR TITLE
Fixed target_name and action parameter bitwidth

### DIFF
--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -637,10 +637,7 @@ const IR::Node *ReplaceHdrMetaField::postorder(IR::Type_Struct *st) {
             if (auto t = (*field).type->to<IR::Type_Bits>()) {
                 auto width = t->width_bits();
                 if (width % 8 != 0) {
-                    if (width < 32)
-                        width = 32;
-                    else
-                        width = 64;
+                    width = getMetadataFieldWidth(width);
                     fields->push_back(
                         new IR::StructField(IR::ID(field->name), IR::Type_Bits::get(width)));
                 } else {

--- a/backends/dpdk/dpdkContext.cpp
+++ b/backends/dpdk/dpdkContext.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include "backend.h"
 #include "control-plane/bfruntime_ext.h"
+#include "dpdkUtils.h"
 #include "printUtils.h"
 namespace DPDK {
 
@@ -349,12 +350,7 @@ Util::JsonObject *DpdkContextGenerator::addMatchAttributes(const IR::P4Table *ta
             for (auto param : *(attr.params)) {
                 if (param->type->is<IR::Type_Bits>()) {
                     param_width = param->type->width_bits();
-                    if (param_width % 8 != 0) {
-                        if (param_width < 32)
-                            param_width = 32;
-                        else
-                            param_width = 64;
-                    }
+                    param_width = getMetadataFieldWidth(param_width);
                 } else if (!param->type->is<IR::Type_Boolean>()) {
                     BUG("Unsupported parameter type %1%", param->type);
                 }
@@ -417,12 +413,7 @@ Util::JsonArray *DpdkContextGenerator::addActions(const IR::P4Table *table,
                 for (auto param : *(attr.params)) {
                     if (param->type->is<IR::Type_Bits>()) {
                         param_width = param->type->width_bits();
-                        if (param_width % 8 != 0) {
-                            if (param_width < 32)
-                                param_width = 32;
-                            else
-                                param_width = 64;
-                        }
+                        param_width = getMetadataFieldWidth(param_width);
                     } else if (!param->type->is<IR::Type_Boolean>()) {
                         BUG("Unsupported parameter type %1%", param->type);
                     }

--- a/backends/dpdk/dpdkContext.cpp
+++ b/backends/dpdk/dpdkContext.cpp
@@ -190,7 +190,7 @@ void DpdkContextGenerator::addKeyField(Util::JsonArray *keyJson, const cstring n
 Util::JsonObject *DpdkContextGenerator::initTableCommonJson(const cstring name,
                                                             const struct TableAttributes &attr) {
     auto *tableJson = new Util::JsonObject();
-    cstring tableName = attr.controlName + "." + name;
+    cstring tableName = name;
     tableJson->emplace("name", attr.externalName);
     tableJson->emplace("target_name", tableName);
     tableJson->emplace("direction", attr.direction);
@@ -349,6 +349,12 @@ Util::JsonObject *DpdkContextGenerator::addMatchAttributes(const IR::P4Table *ta
             for (auto param : *(attr.params)) {
                 if (param->type->is<IR::Type_Bits>()) {
                     param_width = param->type->width_bits();
+                    if (param_width % 8 != 0) {
+                        if (param_width < 32)
+                            param_width = 32;
+                        else
+                            param_width = 64;
+                    }
                 } else if (!param->type->is<IR::Type_Boolean>()) {
                     BUG("Unsupported parameter type %1%", param->type);
                 }
@@ -411,6 +417,12 @@ Util::JsonArray *DpdkContextGenerator::addActions(const IR::P4Table *table,
                 for (auto param : *(attr.params)) {
                     if (param->type->is<IR::Type_Bits>()) {
                         param_width = param->type->width_bits();
+                        if (param_width % 8 != 0) {
+                            if (param_width < 32)
+                                param_width = 32;
+                            else
+                                param_width = 64;
+                        }
                     } else if (!param->type->is<IR::Type_Boolean>()) {
                         BUG("Unsupported parameter type %1%", param->type);
                     }

--- a/backends/dpdk/dpdkUtils.cpp
+++ b/backends/dpdk/dpdkUtils.cpp
@@ -133,4 +133,16 @@ bool reservedNames(P4::ReferenceMap *refMap, std::vector<cstring> names, cstring
     return true;
 }
 
+// Update bitwidth of Metadata fields to 32 or 64 bits if it 8-bit aligned.
+int getMetadataFieldWidth(int width) {
+    BUG_CHECK(width <= 64, "Metadata bit-width expected to be within 64-bits");
+    if (width % 8 != 0) {
+        if (width < 32)
+            return 32;
+        else
+            return 64;
+    }
+    return width;
+}
+
 }  // namespace DPDK

--- a/backends/dpdk/dpdkUtils.h
+++ b/backends/dpdk/dpdkUtils.h
@@ -31,7 +31,7 @@ bool isDirection(const IR::Member *m);
 bool isHeadersStruct(const IR::Type_Struct *st);
 bool isLargeFieldOperand(const IR::Expression *e);
 bool isInsideHeader(const IR::Expression *e);
-
+int getMetadataFieldWidth(int width);
 const IR::Type_Bits *getEightBitAlignedType(const IR::Type_Bits *tb);
 
 // Check for reserved names for DPDK target


### PR DESCRIPTION
Fixed target_name for table : PNA main control name was added to the target_name. However, the target name of a table should match with the name in .spec file. 
DPDK target needs all metadata to be byte aligned. In case of action parameters , the bitwidth was not adjusted  to match with spec file. Fixed it