### PR TITLE
Explicitly use method toString() while moving isValid() Methodcall used as table key to metadata

### DIFF
--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -1666,6 +1666,16 @@ const IR::Node *CopyMatchKeysToSingleStruct::postorder(IR::KeyElement *element) 
     }
 
     auto keyName = element->expression->toString();
+    if (auto m = element->expression->to<IR::MethodCallExpression>()) {
+        /* Moving <hdr>.isValid() used as table key to Metadata */
+        auto mi = P4::MethodInstance::resolve(m, refMap, typeMap);
+        if (auto b = mi->to<P4::BuiltInMethod>()) {
+            if (b->name == "isValid") {
+                keyName = m->method->toString();
+            }
+        }
+    }
+
     bool isHeader = false;
     /* All header fields are prefixed with "h." and metadata fields are prefixed with "m."
      * Prefix the match field with control and table name */


### PR DESCRIPTION
This is required for https://github.com/p4lang/p4c/pull/4354#issuecomment-1914141950
No changes in test output currently, however once above PR is merged in main, some dpdk tests will be broken. Hence, fixing it before merging Kyle's PR.